### PR TITLE
get_working_hoursコマンドの不具合を修正

### DIFF
--- a/app/listeners/commands/get_working_hours.py
+++ b/app/listeners/commands/get_working_hours.py
@@ -52,7 +52,7 @@ def get_working_hours_wrapper(bot_context: BotContext):
                 .group_by(RA.ra_name)
             )
 
-        if working_hours_of_all_RAs.all():  # NOTE: `working_hours_of_all_RAs` is a `sqlalchemy.engine.result.ChunkedIteratorResult` object. Without .all(), it won't be evaluated to false even if it contains no result.
+        if working_hours_of_all_RAs.all():  # NOTE: `working_hours_of_all_RAs` is a `sqlalchemy.engine.result.ChunkedIteratorResult` object. Without .all(), it won't be evaluated to False even if it contains no result.
             message = f':pencil: {year_month if year_month else "今月"}の稼働時間は以下の通りです。'
             for working_hour in working_hours_of_all_RAs:
                 ra_name, working_hours = working_hour._tuple()

--- a/app/listeners/commands/get_working_hours.py
+++ b/app/listeners/commands/get_working_hours.py
@@ -52,7 +52,7 @@ def get_working_hours_wrapper(bot_context: BotContext):
                 .group_by(RA.ra_name)
             )
 
-        if working_hours_of_all_RAs:
+        if working_hours_of_all_RAs.all():  # NOTE: `working_hours_of_all_RAs` is a `sqlalchemy.engine.result.ChunkedIteratorResult` object. Without .all(), it won't be evaluated to false even if it contains no result.
             message = f':pencil: {year_month if year_month else "今月"}の稼働時間は以下の通りです。'
             for working_hour in working_hours_of_all_RAs:
                 ra_name, working_hours = working_hour._tuple()


### PR DESCRIPTION
- if文の条件式が誤っており常にTrue側に分岐するようになっていたため修正した
- 勤務が1件も無いときは正しく`:beach_with_umbrella: {year_month if year_month else "今月"}の稼働時間はありません。`が表示されるようになった．