### PR TITLE
get_working_hoursの不具合の対処方法を修正

### DIFF
--- a/app/listeners/commands/get_working_hours.py
+++ b/app/listeners/commands/get_working_hours.py
@@ -50,9 +50,9 @@ def get_working_hours_wrapper(bot_context: BotContext):
                     < first_day_of_this_month + relativedelta.relativedelta(months=1),
                 )
                 .group_by(RA.ra_name)
-            )
+            ).all()
 
-        if working_hours_of_all_RAs.all():  # NOTE: `working_hours_of_all_RAs` is a `sqlalchemy.engine.result.ChunkedIteratorResult` object. Without .all(), it won't be evaluated to False even if it contains no result.
+        if working_hours_of_all_RAs:
             message = f':pencil: {year_month if year_month else "今月"}の稼働時間は以下の通りです。'
             for working_hour in working_hours_of_all_RAs:
                 ra_name, working_hours = working_hour._tuple()


### PR DESCRIPTION
- SQLAlchemyから返却された`Result`から何度も中身を取り出そうとしていたので，最初に一回だけ`.all()`で取り出して以降はそれを使うように修正した．