### PR TITLE
ロギングの実装

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /usr/src/app
 COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
 
-CMD [ "python", "./run.py", "--botconfig", "./config/bot_config.json"]
+CMD [ "python", "./run.py", "--botconfig", "./config/bot_config.json", "--bot_verbose"]

--- a/app/listeners/commands/admin_download_all_records.py
+++ b/app/listeners/commands/admin_download_all_records.py
@@ -71,7 +71,9 @@ def admin_download_all_records_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=f':beach_with_umbrella: {year_month if year_month else "今月"}の勤務記録はありません。',
                 )
-                botctx.logger.info(f"found no work record in {date} for any user")
+                botctx.logger.info(
+                    f"found no work record in {date.year}/{date.month} for any user"
+                )
                 return
 
         # make CSV file

--- a/app/listeners/commands/admin_download_all_records.py
+++ b/app/listeners/commands/admin_download_all_records.py
@@ -29,6 +29,9 @@ def admin_download_all_records_wrapper(bot_context: BotContext):
                 user=context.actor_user_id,
                 text=":x: あなたはこのコマンドを使うことができません。",
             )
+            botctx.logger.info(
+                f"slack user {context.actor_user_id} tried to execute /admin_download_all_records, but is not allowed to"
+            )
             return
 
         year_month = command["text"].strip()
@@ -40,6 +43,9 @@ def admin_download_all_records_wrapper(bot_context: BotContext):
                     channel=context.channel_id,
                     user=context.actor_user_id,
                     text=":x: `/download_all_working_records 2023/11` のように実行してください。",
+                )
+                botctx.logger.info(
+                    f"slack user {context.actor_user_id} executed /admin_download_all_records with invalid argument: {year_month}"
                 )
                 return
         else:
@@ -65,6 +71,7 @@ def admin_download_all_records_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=f':beach_with_umbrella: {year_month if year_month else "今月"}の勤務記録はありません。',
                 )
+                botctx.logger.info(f"found no work record in {year_month} for any user")
                 return
 
         # make CSV file
@@ -118,6 +125,10 @@ def admin_download_all_records_wrapper(bot_context: BotContext):
             channel=context.channel_id,
             user=context.actor_user_id,
             text=":page_facing_up: DMにCSVファイルを送信しました。",
+        )
+
+        botctx.logger.info(
+            f"sent CSV file of all work records to slack user {context.actor_user_id}"
         )
 
     return admin_download_all_records

--- a/app/listeners/commands/admin_download_all_records.py
+++ b/app/listeners/commands/admin_download_all_records.py
@@ -71,7 +71,7 @@ def admin_download_all_records_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=f':beach_with_umbrella: {year_month if year_month else "今月"}の勤務記録はありません。',
                 )
-                botctx.logger.info(f"found no work record in {year_month} for any user")
+                botctx.logger.info(f"found no work record in {date} for any user")
                 return
 
         # make CSV file

--- a/app/listeners/commands/download_csv.py
+++ b/app/listeners/commands/download_csv.py
@@ -33,6 +33,9 @@ def download_csv_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=":x: `/download_csv 2023/11` のように実行してください。",
                 )
+                botctx.logger.info(
+                    f"slack user {context.actor_user_id} executed /download_csv with invalid argument: {year_month}"
+                )
                 return
         else:
             date = datetime.date.today()
@@ -57,6 +60,9 @@ def download_csv_wrapper(bot_context: BotContext):
                     channel=context.channel_id,
                     user=context.actor_user_id,
                     text=f':beach_with_umbrella: {year_month if year_month else "今月"}の稼働時間はありません。',
+                )
+                botctx.logger.info(
+                    f"found no work record in {year_month} for slack user {context.actor_user_id}"
                 )
                 return
 
@@ -102,6 +108,10 @@ def download_csv_wrapper(bot_context: BotContext):
             channel=context.channel_id,
             user=context.actor_user_id,
             text=":page_facing_up: DMにCSVファイルを送信しました。",
+        )
+
+        botctx.logger.info(
+            f"sent CSV file of work record to slack user {context.actor_user_id}"
         )
 
     return download_csv

--- a/app/listeners/commands/download_csv.py
+++ b/app/listeners/commands/download_csv.py
@@ -62,7 +62,7 @@ def download_csv_wrapper(bot_context: BotContext):
                     text=f':beach_with_umbrella: {year_month if year_month else "今月"}の稼働時間はありません。',
                 )
                 botctx.logger.info(
-                    f"found no work record in {date} for slack user {context.actor_user_id}"
+                    f"found no work record in {date.year}/{date.month} for slack user {context.actor_user_id}"
                 )
                 return
 

--- a/app/listeners/commands/download_csv.py
+++ b/app/listeners/commands/download_csv.py
@@ -62,7 +62,7 @@ def download_csv_wrapper(bot_context: BotContext):
                     text=f':beach_with_umbrella: {year_month if year_month else "今月"}の稼働時間はありません。',
                 )
                 botctx.logger.info(
-                    f"found no work record in {year_month} for slack user {context.actor_user_id}"
+                    f"found no work record in {date} for slack user {context.actor_user_id}"
                 )
                 return
 

--- a/app/listeners/commands/get_working_hours.py
+++ b/app/listeners/commands/get_working_hours.py
@@ -78,7 +78,7 @@ def get_working_hours_wrapper(bot_context: BotContext):
                 text=f':beach_with_umbrella: {year_month if year_month else "今月"}の稼働時間はありません。',
             )
             botctx.logger.info(
-                f"found no work record in {year_month} for slack user {context.actor_user_id}"
+                f"found no work record in {date} for slack user {context.actor_user_id}"
             )
 
     return get_working_hours

--- a/app/listeners/commands/get_working_hours.py
+++ b/app/listeners/commands/get_working_hours.py
@@ -78,7 +78,7 @@ def get_working_hours_wrapper(bot_context: BotContext):
                 text=f':beach_with_umbrella: {year_month if year_month else "今月"}の稼働時間はありません。',
             )
             botctx.logger.info(
-                f"found no work record in {date} for slack user {context.actor_user_id}"
+                f"found no work record in {date.year}/{date.month} for slack user {context.actor_user_id}"
             )
 
     return get_working_hours

--- a/app/listeners/commands/get_working_hours.py
+++ b/app/listeners/commands/get_working_hours.py
@@ -32,6 +32,9 @@ def get_working_hours_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=":x: `/get_working_hours 2023/11` のように実行してください。",
                 )
+                botctx.logger.info(
+                    f"slack user {context.actor_user_id} executed /get_working_hours with invalid argument: {year_month}"
+                )
                 return
         else:
             date = datetime.date.today()
@@ -40,7 +43,10 @@ def get_working_hours_wrapper(bot_context: BotContext):
         with botctx.db_sessmaker() as sess:
             # added type hint since SQLAlchemy can't infer it
             working_hours_of_all_RAs = sess.execute(
-                select(RA.ra_name, sqlfuncs.sum(TimeCard.duration - TimeCard.break_duration))
+                select(
+                    RA.ra_name,
+                    sqlfuncs.sum(TimeCard.duration - TimeCard.break_duration),
+                )
                 .join(RA, RA.id == TimeCard.ra_id)
                 .join(User, User.id == RA.user_id)
                 .where(
@@ -64,11 +70,15 @@ def get_working_hours_wrapper(bot_context: BotContext):
             client.chat_postEphemeral(
                 channel=context.channel_id, user=context.actor_user_id, text=message
             )
+            botctx.logger.info(f"sent work hours to slack user {context.actor_user_id}")
         else:
             client.chat_postEphemeral(
                 channel=context.channel_id,
                 user=context.actor_user_id,
                 text=f':beach_with_umbrella: {year_month if year_month else "今月"}の稼働時間はありません。',
+            )
+            botctx.logger.info(
+                f"found no work record in {year_month} for slack user {context.actor_user_id}"
             )
 
     return get_working_hours

--- a/app/listeners/commands/register_RA.py
+++ b/app/listeners/commands/register_RA.py
@@ -25,6 +25,9 @@ def register_RA_wrapper(bot_context: BotContext):
                 user=context.actor_user_id,
                 text=":x: `/register_ra <RA区分名>` のように実行してください。",
             )
+            botctx.logger.info(
+                f"slack user {context.actor_user_id} executed /register_RA command with no argument"
+            )
             return
 
         # check that the user is already registered
@@ -38,6 +41,9 @@ def register_RA_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=":x: `/init <氏名>` で先にユーザ登録を行ってください。",
                 )
+                botctx.logger.info(
+                    f"slack user {context.actor_user_id} executed /register_RA, but is not registered as bot user yet"
+                )
                 return
 
             try:
@@ -50,12 +56,23 @@ def register_RA_wrapper(bot_context: BotContext):
                 sess.commit()
             except Exception:
                 sess.rollback()
+                client.chat_postEphemeral(
+                    channel=context.channel_id,
+                    user=context.actor_user_id,
+                    text=":x: 何らかのデータベースエラーによりRAを登録できませんでした。",
+                )
+                botctx.logger.exception(
+                    f"failed to register RA {ra_name} for slack user {context.actor_user_id} due to a database error"
+                )
                 raise
             else:
                 client.chat_postEphemeral(
                     channel=context.channel_id,
                     user=context.actor_user_id,
                     text=f':white_check_mark: RA "{ra_name}" を登録しました。',
+                )
+                botctx.logger.info(
+                    f"registered RA {ra_name} for slack user {context.actor_user_id}"
                 )
 
     return register_RA

--- a/app/listeners/commands/register_RA.py
+++ b/app/listeners/commands/register_RA.py
@@ -26,7 +26,7 @@ def register_RA_wrapper(bot_context: BotContext):
                 text=":x: `/register_ra <RA区分名>` のように実行してください。",
             )
             botctx.logger.info(
-                f"slack user {context.actor_user_id} executed /register_RA command with no argument"
+                f"slack user {context.actor_user_id} executed /register_ra command with no argument"
             )
             return
 
@@ -42,7 +42,7 @@ def register_RA_wrapper(bot_context: BotContext):
                     text=":x: `/init <氏名>` で先にユーザ登録を行ってください。",
                 )
                 botctx.logger.info(
-                    f"slack user {context.actor_user_id} executed /register_RA, but is not registered as bot user yet"
+                    f"slack user {context.actor_user_id} executed /register_ra, but is not registered as bot user yet"
                 )
                 return
 

--- a/app/listeners/events/on_mention.py
+++ b/app/listeners/events/on_mention.py
@@ -76,7 +76,7 @@ def on_mention_wrapper(bot_context: BotContext):
                 ],
             )
             botctx.logger.info(
-                f"user {context.actor_user_id} sent work record in invalid format"
+                f"slack user {context.actor_user_id} sent work record in invalid format"
             )
             return
 
@@ -101,7 +101,7 @@ def on_mention_wrapper(bot_context: BotContext):
                     text=f':x: あなたは "{ra_name}" という名称のRAを登録していないか、ユーザ登録を完了していません。',
                 )
                 botctx.logger.info(
-                    f"user {context.actor_user_id} sent work record for unknown RA: {ra_name}"
+                    f"slack user {context.actor_user_id} sent work record for unknown RA: {ra_name}"
                 )
                 return
 
@@ -120,7 +120,7 @@ def on_mention_wrapper(bot_context: BotContext):
                 ),
             )
             botctx.logger.info(
-                f"user {context.actor_user_id} sent work record whose date is in invalid format"
+                f"slack user {context.actor_user_id} sent work record whose date is in invalid format"
             )
             return
 
@@ -172,7 +172,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         text=":x: 何らかのデータベースエラーにより記録できませんでした。",
                     )
                     botctx.logger.exception(
-                        f"failed to record work by user {context.actor_user_id} for {ra_name} due to a database error"
+                        f"failed to record work by slack user {context.actor_user_id} for {ra_name} due to a database error"
                     )
                     raise
                 else:
@@ -189,7 +189,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         ),
                     )
                     botctx.logger.info(
-                        f"recorded work by user {context.actor_user_id} for {ra_name}"
+                        f"recorded work by slack user {context.actor_user_id} for {ra_name}"
                     )
             else:  # existing record was found, so update it
                 try:
@@ -208,7 +208,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         text=":x: 何らかのデータベースエラーにより更新できませんでした。",
                     )
                     botctx.logger.exception(
-                        f"failed to update work record by user {context.actor_user_id} for {ra_name} due to a database error"
+                        f"failed to update work record by slack user {context.actor_user_id} for {ra_name} due to a database error"
                     )
                     raise
                 else:
@@ -225,7 +225,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         ),
                     )
                     botctx.logger.info(
-                        f"updated work record by user {context.actor_user_id} for {ra_name}"
+                        f"updated work record by slack user {context.actor_user_id} for {ra_name}"
                     )
 
     return on_mention

--- a/app/listeners/events/on_mention.py
+++ b/app/listeners/events/on_mention.py
@@ -172,7 +172,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         text=":x: 何らかのデータベースエラーにより記録できませんでした。",
                     )
                     botctx.logger.exception(
-                        f"failed to record work by slack user {context.actor_user_id} for {ra_name} due to a database error"
+                        f"failed to record work by slack user {context.actor_user_id} for RA {ra_name} due to a database error"
                     )
                     raise
                 else:
@@ -189,7 +189,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         ),
                     )
                     botctx.logger.info(
-                        f"recorded work by slack user {context.actor_user_id} for {ra_name}"
+                        f"recorded work by slack user {context.actor_user_id} for RA {ra_name}"
                     )
             else:  # existing record was found, so update it
                 try:
@@ -208,7 +208,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         text=":x: 何らかのデータベースエラーにより更新できませんでした。",
                     )
                     botctx.logger.exception(
-                        f"failed to update work record by slack user {context.actor_user_id} for {ra_name} due to a database error"
+                        f"failed to update work record by slack user {context.actor_user_id} for RA {ra_name} due to a database error"
                     )
                     raise
                 else:
@@ -225,7 +225,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         ),
                     )
                     botctx.logger.info(
-                        f"updated work record by slack user {context.actor_user_id} for {ra_name}"
+                        f"updated work record by slack user {context.actor_user_id} for RA {ra_name}"
                     )
 
     return on_mention

--- a/app/listeners/events/on_mention.py
+++ b/app/listeners/events/on_mention.py
@@ -189,7 +189,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         ),
                     )
                     botctx.logger.info(
-                        f"recorded work by slack user {context.actor_user_id} for RA {ra_name}"
+                        f"recorded work by slack user {context.actor_user_id} for RA {ra_name}: {description}"
                     )
             else:  # existing record was found, so update it
                 try:
@@ -225,7 +225,7 @@ def on_mention_wrapper(bot_context: BotContext):
                         ),
                     )
                     botctx.logger.info(
-                        f"updated work record by slack user {context.actor_user_id} for RA {ra_name}"
+                        f"updated work record by slack user {context.actor_user_id} for RA {ra_name}: {description}"
                     )
 
     return on_mention

--- a/app/listeners/events/on_mention.py
+++ b/app/listeners/events/on_mention.py
@@ -75,6 +75,9 @@ def on_mention_wrapper(bot_context: BotContext):
                     ),
                 ],
             )
+            botctx.logger.info(
+                f"user {context.actor_user_id} sent work record in invalid format"
+            )
             return
 
         # extract information from user's message
@@ -97,6 +100,9 @@ def on_mention_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=f':x: "{ra_name}" という名称のRAは登録されていません。',
                 )
+                botctx.logger.info(
+                    f"user {context.actor_user_id} sent work record for unknown RA: {ra_name}"
+                )
                 return
 
         user_id, ra_id, ra_name = user_ra_data._tuple()
@@ -112,6 +118,9 @@ def on_mention_wrapper(bot_context: BotContext):
                         `2023/11/18 10:00-18:00 休憩01:00`
                     """
                 ),
+            )
+            botctx.logger.info(
+                f"user {context.actor_user_id} sent work record whose date is in invalid format"
             )
             return
 
@@ -162,6 +171,9 @@ def on_mention_wrapper(bot_context: BotContext):
                         user=context.actor_user_id,
                         text=":x: 何らかのデータベースエラーにより記録できませんでした。",
                     )
+                    botctx.logger.exception(
+                        f"failed to record work by user {context.actor_user_id} for {ra_name} due to a database error"
+                    )
                     raise
                 else:
                     client.chat_postEphemeral(
@@ -175,6 +187,9 @@ def on_mention_wrapper(bot_context: BotContext):
                             f"休憩時間: {break_time.hour:02}:{break_time.minute:02}\n"
                             f"作業内容: {description}"
                         ),
+                    )
+                    botctx.logger.info(
+                        f"recorded work by user {context.actor_user_id} for {ra_name}"
                     )
             else:  # existing record was found, so update it
                 try:
@@ -192,6 +207,9 @@ def on_mention_wrapper(bot_context: BotContext):
                         user=context.actor_user_id,
                         text=":x: 何らかのデータベースエラーにより更新できませんでした。",
                     )
+                    botctx.logger.exception(
+                        f"failed to update work record by user {context.actor_user_id} for {ra_name} due to a database error"
+                    )
                     raise
                 else:
                     client.chat_postEphemeral(
@@ -205,6 +223,9 @@ def on_mention_wrapper(bot_context: BotContext):
                             f"休憩時間: {break_time.hour:02}:{break_time.minute:02}\n"
                             f"作業内容: {description}"
                         ),
+                    )
+                    botctx.logger.info(
+                        f"updated work record by user {context.actor_user_id} for {ra_name}"
                     )
 
     return on_mention

--- a/app/listeners/events/on_mention.py
+++ b/app/listeners/events/on_mention.py
@@ -98,7 +98,7 @@ def on_mention_wrapper(bot_context: BotContext):
                 client.chat_postEphemeral(
                     channel=context.channel_id,
                     user=context.actor_user_id,
-                    text=f':x: "{ra_name}" という名称のRAは登録されていません。',
+                    text=f':x: あなたは "{ra_name}" という名称のRAを登録していないか、ユーザ登録を完了していません。',
                 )
                 botctx.logger.info(
                     f"user {context.actor_user_id} sent work record for unknown RA: {ra_name}"

--- a/app/listeners/events/on_message_delete.py
+++ b/app/listeners/events/on_message_delete.py
@@ -39,7 +39,7 @@ def on_message_delete_wrapper(bot_context: BotContext):
                     text=":x: 何らかのデータベースエラーにより削除できませんでした。",
                 )
                 botctx.logger.exception(
-                    f"failed to delete work record by slack user {context.actor_user_id} due to a database error"
+                    f"failed to delete work record whose ts is {deleted_slack_message_ts} by slack user {context.actor_user_id} due to a database error"
                 )
                 raise
             else:

--- a/app/listeners/events/on_message_delete.py
+++ b/app/listeners/events/on_message_delete.py
@@ -39,7 +39,7 @@ def on_message_delete_wrapper(bot_context: BotContext):
                     text=":x: 何らかのデータベースエラーにより削除できませんでした。",
                 )
                 botctx.logger.exception(
-                    f"failed to delete work record by user {context.actor_user_id} due to a database error"
+                    f"failed to delete work record by slack user {context.actor_user_id} due to a database error"
                 )
                 raise
             else:
@@ -49,7 +49,7 @@ def on_message_delete_wrapper(bot_context: BotContext):
                     text=f":wastebasket: {record_to_delete.start_time}から{record_to_delete.end_time}の作業記録を削除しました。",
                 )
                 botctx.logger.info(
-                    f"deleted work record by user {context.actor_user_id}"
+                    f"deleted work record by slack user {context.actor_user_id}"
                 )
 
     return on_message_delete

--- a/app/listeners/events/on_message_delete.py
+++ b/app/listeners/events/on_message_delete.py
@@ -49,7 +49,7 @@ def on_message_delete_wrapper(bot_context: BotContext):
                     text=f":wastebasket: {record_to_delete.start_time}から{record_to_delete.end_time}の作業記録を削除しました。",
                 )
                 botctx.logger.info(
-                    f"deleted work record by slack user {context.actor_user_id}"
+                    f"deleted work record by slack user {context.actor_user_id} from {record_to_delete.start_time} to {record_to_delete.end_time}: {record_to_delete.description}"
                 )
 
     return on_message_delete

--- a/app/listeners/events/on_message_delete.py
+++ b/app/listeners/events/on_message_delete.py
@@ -38,12 +38,18 @@ def on_message_delete_wrapper(bot_context: BotContext):
                     user=context.actor_user_id,
                     text=":x: 何らかのデータベースエラーにより削除できませんでした。",
                 )
+                botctx.logger.exception(
+                    f"failed to delete work record by user {context.actor_user_id} due to a database error"
+                )
                 raise
             else:
                 client.chat_postEphemeral(
                     channel=context.channel_id,
                     user=context.actor_user_id,
                     text=f":wastebasket: {record_to_delete.start_time}から{record_to_delete.end_time}の作業記録を削除しました。",
+                )
+                botctx.logger.info(
+                    f"deleted work record by user {context.actor_user_id}"
                 )
 
     return on_message_delete

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -46,5 +46,7 @@ services:
         "--botconfig",
         "./config/bot_config.json",
         "--slackconfig",
-        "./config/slack_secret_config.json"
+        "./config/slack_secret_config.json",
+        "--bot_verbose",
+        "--db_verbose"
       ]

--- a/run.py
+++ b/run.py
@@ -21,6 +21,14 @@ parser.add_argument(
     "--slackconfig",
     help="JSON file containing slack configuration (if not given, environment variables will be used)",
 )
+parser.add_argument(
+    "--bot_verbose",
+    help="Enable verbose logging from the bot application",
+    action="store_true",
+)
+parser.add_argument(
+    "--db_verbose", help="Enable verbose logging from SQLAlchemy", action="store_true"
+)
 
 if __name__ == "__main__":
     args = parser.parse_args()
@@ -30,7 +38,10 @@ if __name__ == "__main__":
 
     ### create logger for logs from this app ###
     logger = logging.getLogger("bot")
-    logger.setLevel(logging.INFO)
+    if args.bot_verbose:
+        logger.setLevel(logging.INFO)
+    else:
+        logger.setLevel(logging.WARNING)
 
     ### load config ###
     # load config file for bot
@@ -54,8 +65,9 @@ if __name__ == "__main__":
         slack_config = SlackConfig.from_env()
 
     ### setup db ###
+    sqlalchemy_loglevel = logging.INFO if args.db_verbose else logging.WARNING
     db_sessmaker = setup_db_and_get_sessionmaker(
-        db_config=db_config, sqlalchemy_loglevel=logging.INFO
+        db_config=db_config, sqlalchemy_loglevel=sqlalchemy_loglevel
     )
 
     # wrap objects in BotContext


### PR DESCRIPTION
- ユーザが送信したデータのフォーマットが不正であるなどの理由でコマンドが途中で修了した場合に、ログを参照して確認できるようにした
- botアプリケーションとSQLAlchemyそれぞれのログレベルを制御するスイッチを導入した